### PR TITLE
added s3 outlets to example flow

### DIFF
--- a/environment.js
+++ b/environment.js
@@ -1,21 +1,23 @@
-
 export const updateTokenConfig = (config) => {
 
     if (document.location.hostname !== "localhost"){
 
-        /*if (document.location.hostname.startsWith("192.168.")){
+        if (document.location.hostname.startsWith("192.168.")){
             config.tokenOrigin = document.location.protocol + "//" + document.location.hostname + ":3002";
             return config;
-        }*/
+        }
 
-        if (document.location.pathname.indexOf("token-negotiator-examples") === 1 ||
-			document.location.hostname.indexOf("stltesting.tk") > -1){
-            config.tokenOrigin = "https://stltesting.tk/token-outlet/";
-			config.attestationOrigin = "https://test.attestation.id/";
-        } else if (document.location.pathname.indexOf("token-negotiator-gh-pages") === 1) {
-            config.tokenOrigin = "https://tokenscript.github.io/token-negotiator-gh-pages/token-outlet-website/";
+        if (document.location.pathname.indexOf("token-negotiator-examples") === 1){
+            // config.tokenOrigin = "https://tokenscript.github.io/token-negotiator-examples/token-outlet-website/";
+            config.tokenOrigin = "https://outlet-stage.brandconnector.io/";
+        } else {
+            // config.tokenOrigin = "https://tokenscript.github.io/token-negotiator-gh-pages/token-outlet-website/";
+            config.tokenOrigin = "https://outlet.brandconnector.io/";
         }
     }
 
     return config;
 }
+
+
+


### PR DESCRIPTION
Hi @micwallace, @snowwhitedev, @BankiLouis.

To help test the cross origin logic of Brand Connector with regards to the off chain attestations flow I've pointed the ENV urls to AWS end points which host the outlet. 

These outlet urls are updated when we merge to staging and main (based on the env we are building to etc).

This to help us ensure our off chain flow technology is working when we deploy to staging and production.

Please review the changes and approve when ready. 