### PR TITLE
Fix: ecommerce example

### DIFF
--- a/ecommerce-store-website/src/pages/_app.js
+++ b/ecommerce-store-website/src/pages/_app.js
@@ -119,6 +119,7 @@ export default function App({ Component, pageProps }) {
 			});
 
 			window.negotiator.on('connected-wallet', (_connectedWallet) => {
+				window.connectedWallet = _connectedWallet;
 				resetIssuers(window.connectedWallet.chainId);
 			});
 


### PR DESCRIPTION
@nicktaras this fixes an issue in ecommerce example that is caused when a wallet is already connected and the page is reloaded