### PR TITLE
test: 💍 make e2e could run locally

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -34,13 +34,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: "https://npm.pkg.github.com"
 
       - name: Build
         run: |
-          
           npm install
-          
+
           if [[ "${GITHUB_EVENT_NAME}" = push ]]; then
             NEGOTIATOR_BRANCH="${GITHUB_REF_NAME}"
           fi
@@ -48,15 +47,15 @@ jobs:
             echo "Negotiator branch $NEGOTIATOR_BRANCH requested, updating package.json files"
             scripts/use_negotiator_branch.js $NEGOTIATOR_BRANCH
           fi
-          
+
           export BASE_PATH=/token-negotiator-examples/ecommerce-store-website
           export MAX_PROCESSES=5
-        
+
           npm run install-examples
           npm run clean
           npm run build
           npm run copy-artifacts
-          
+
           short_sha="${GITHUB_SHA:0:7}"
           build_version="${GITHUB_REF_NAME}-${short_sha}"
           build_time="$(date --utc --iso-8601=seconds)"

--- a/e2e-test-suite/README.md
+++ b/e2e-test-suite/README.md
@@ -1,12 +1,29 @@
 # token-negotiator-test-suite
 
 ## ⚙Setup
-* Install dependencies: `npm i`
-* Run tests in staging env: `npm run test:stage`
-* Run tests in production env: `npm run test:prod`
+
+- Install dependencies: `npm i`
+- Run tests in staging env: `npm run test:stage`
+- Run tests in production env: `npm run test:prod`
+- Run tests locally:
+
+  ```sh
+  # You should first build the website locally
+  cd ../
+  npm ci
+  export BASE_PATH=/token-negotiator-examples/ecommerce-store-website
+  export MAX_PROCESSES=5
+  npm run install-examples && npm run clean && npm run build && npm run copy-artifacts
+
+  # Run tests locally
+  cd -
+  npm test
+  ```
 
 ## 🗂Folder Structure
-* Overview of the test framework's main structure:
+
+- Overview of the test framework's main structure:
+
 ```text
 project_dir
 └── apis
@@ -24,13 +41,14 @@ project_dir
 └── playwright.config.ts
 ```
 
-* **/apis:** Contains files that utilize public APIs (e.g. email API).
-* **/extensions:** Contains Chrome browser extension folders with data files (e.g. MetaMask extension).
-* **/fixtures:** Contains test data to be used in test framework
-* **/pages:** Contains the Page Object Model of the test framework.
-* **/tests:** Contains the spec files for e2e tests.
-* **/utils:** Contains the utility files with helper functions.
-* **/playwright.config.ts:** Contains Playwright global configuration options.
+- **/apis:** Contains files that utilize public APIs (e.g. email API).
+- **/extensions:** Contains Chrome browser extension folders with data files (e.g. MetaMask extension).
+- **/fixtures:** Contains test data to be used in test framework
+- **/pages:** Contains the Page Object Model of the test framework.
+- **/tests:** Contains the spec files for e2e tests.
+- **/utils:** Contains the utility files with helper functions.
+- **/playwright.config.ts:** Contains Playwright global configuration options.
 
 ## 📖Documentation
+
 <a href="https://playwright.dev/docs/intro">Playwright doc</a>

--- a/e2e-test-suite/fixtures/data.json
+++ b/e2e-test-suite/fixtures/data.json
@@ -7,7 +7,8 @@
     },
     "urlEnv": {
         "prod": "https://tokenscript.github.io/token-negotiator-gh-pages/",
-        "stage": "https://tokenscript.github.io/token-negotiator-examples/"
+        "stage": "https://tokenscript.github.io/token-negotiator-examples/",
+        "test": "http://127.0.0.1:8080/"
     },
     "urlExamples": {
         "ticketIssuer": "ticket-issuer-url-website",

--- a/e2e-test-suite/playwright.config.ts
+++ b/e2e-test-suite/playwright.config.ts
@@ -1,11 +1,11 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
-import Helper from './utils/helper.util';
+import type { PlaywrightTestConfig } from "@playwright/test";
+import Helper from "./utils/helper.util";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 const config: PlaywrightTestConfig = {
-  testDir: './tests',
+  testDir: "./tests",
   /* Maximum time one test can run for. */
   timeout: 0,
   expect: {
@@ -13,7 +13,7 @@ const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000
+    timeout: 5000,
   },
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
@@ -22,7 +22,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
@@ -31,29 +31,35 @@ const config: PlaywrightTestConfig = {
     // baseURL: process.env.URL ?? 'https://tokenscript.github.io/token-negotiator-examples/',
     baseURL: Helper.getBaseURL(),
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
     /* Takes screenshot on failure */
-    screenshot: 'only-on-failure',
+    screenshot: "only-on-failure",
     /* Run test in headless */
-    headless: false,
+    headless: process.env.CI === "true",
     /* Set page width and height */
     viewport: {
       width: 1280,
-      height: 640
+      height: 640,
     },
     // channel: process.env.channel ?? 'chromium'
   },
   projects: [
     {
-      name: 'chrome',
+      name: "chrome",
     },
     {
-      name: 'edge',
-      use: { 
-        channel: 'msedge'
-      }
+      name: "edge",
+      use: {
+        channel: "msedge",
+      },
     },
-  ]
+  ],
+  // Run your local dev server before starting the tests.
+  webServer: {
+    command: "npx -y http-server ../build/",
+    url: "http://127.0.0.1:8080",
+    reuseExistingServer: !process.env.CI,
+  },
 };
 
 export default config;

--- a/e2e-test-suite/utils/helper.util.ts
+++ b/e2e-test-suite/utils/helper.util.ts
@@ -10,7 +10,7 @@ export default class Helper {
             case 'stage':
                 return data.urlEnv.stage
             default:
-                return data.urlEnv.stage
+                return data.urlEnv.test
         }
     }
 }


### PR DESCRIPTION
This PR will allow e2e could run locally.

What I modified:

- add [webServer](https://playwright.dev/docs/test-webserver) config in `playwright.config.ts`
- add run locally steps in `README.md`

In short, that means we should build artifacts first and run locally with [http-server](https://www.npmjs.com/package/http-server) for testing.

But now it runs failed. Seems the reason is `An error occurred loading tokens`. But I don't why the web request `http://localhost:3002/`. Would you please help ?

![image](https://user-images.githubusercontent.com/5327677/232446695-5b0030ad-b118-4ddf-a121-8296c6634a66.png)

Related ticket: https://smarttokenlabs.atlassian.net/browse/TKS-28