### PR TITLE
Fix ecommerce-store-website example by updating npm start script

### DIFF
--- a/ecommerce-store-website/package.json
+++ b/ecommerce-store-website/package.json
@@ -5,7 +5,7 @@
 		"dev": "next dev",
 		"build-without-export": "next build",
 		"build": "next build && next export",
-		"start": "next start -p 3004",
+		"start": "next build && next start -p 3004",
 		"lint": "next lint"
 	},
 	"dependencies": {


### PR DESCRIPTION
Running `npm run start` from the root of this repo as per README's instructions will consequently trigger an `npm run start` in each example by using the `run_batch.js` script.

This will fail, in a clean copy, when it's time to run "ecommerce-store-website" as it can't find a "production build" in the `.next` directory; `next build` needs to be run first to generate that build.

This PR fixes that by adding a `next build` instruction to the start command so this example can be executed without an explicit previous building, therefore maintaining consistency with the way the rest of the examples can be executed.

